### PR TITLE
docs(examples): Add text language identifiers to code blocks

### DIFF
--- a/orbit-examples/cross-protocol/README.md
+++ b/orbit-examples/cross-protocol/README.md
@@ -32,7 +32,7 @@ REST API   ──┘
 
 ## Examples Structure
 
-```
+```text
 cross-protocol/
 ├── README.md                              # This file
 ├── 01_write_postgres_read_redis.py        # SQL write, Redis read


### PR DESCRIPTION
Updated all markdown files in orbit-examples to use text language identifier for ASCII diagrams and directory structure code blocks.

This improves syntax highlighting and rendering in documentation viewers.

Files updated:
- cross-protocol/README.md
- All other example READMEs already updated manually

Changes:
- Added text markers to directory structure diagrams
- Improved code block formatting consistency