### PR TITLE
feat(server): enable REST API and improve protocol startup

### DIFF
--- a/orbit/server/src/main.rs
+++ b/orbit/server/src/main.rs
@@ -41,6 +41,8 @@ use orbit_server::protocols::mysql::MySqlConfig;
 use orbit_server::protocols::persistence::redis_data::RedisDataProvider;
 use orbit_server::protocols::postgres_wire::sql::execution::hybrid::HybridStorageConfig;
 use orbit_server::protocols::postgres_wire::{QueryEngine, RocksDbTableStorage};
+use orbit_server::protocols::mongodb::MongoDbServer;
+use orbit_server::protocols::rest::{RestApiServer, server::RestApiConfig};
 use orbit_server::protocols::{CqlServer, MySqlServer, PostgresServer, RespServer};
 use orbit_server::unified_storage::{UnifiedStorageIntegration, UnifiedStorageIntegrationConfig};
 use orbit_server::OrbitServerBuilder;
@@ -333,6 +335,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_port(args.grpc_port)
         .with_postgres_enabled(false)
         .with_redis_enabled(false)
+        .with_mongodb_enabled(false)
         .build()
         .await?;
 
@@ -767,17 +770,58 @@ async fn main() -> Result<(), Box<dyn Error>> {
     protocol_handles.push(aql_handle);
     debug!("[AQL] AQL/ArangoDB protocol adapter started on port 8529");
 
+    // Start REST API server (port 8080 by default)
+    let rest_bind_addr = format!("{}:{}", args.bind, args.http_port);
+    let rest_config = RestApiConfig {
+        bind_address: rest_bind_addr.clone(),
+        enable_cors: true,
+        enable_tracing: true,
+        api_prefix: "/api/v1".to_string(),
+    };
+
+    // Create OrbitClient for REST API
+    let rest_client_config = orbit_client::OrbitClientConfig {
+        server_urls: vec![format!("http://{}:{}", args.bind, args.grpc_port)],
+        namespace: "default".to_string(),
+        ..Default::default()
+    };
+    let rest_orbit_client = orbit_client::OrbitClient::new_offline(rest_client_config).await?;
+
+    let rest_server = RestApiServer::new(rest_orbit_client, rest_config);
+    let rest_handle = tokio::spawn(async move {
+        rest_server
+            .run()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    });
+    protocol_handles.push(rest_handle);
+    info!("[REST] REST API server started on port {}", args.http_port);
+
+    // Start MongoDB server (port 27017)
+    let mongodb_bind_addr = format!("{}:27017", args.bind);
+    let mongodb_server = MongoDbServer::new(mongodb_bind_addr);
+    let mongodb_handle = tokio::spawn(async move {
+        mongodb_server
+            .run()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    });
+    protocol_handles.push(mongodb_handle);
+    info!("[MongoDB] MongoDB protocol server started on port 27017");
+
     info!("=========================================");
     info!("    Orbit Server Ready!");
     info!("=========================================");
-    debug!("  gRPC:       {}:{}", args.bind, args.grpc_port);
-    debug!("  PostgreSQL: {}:{}", args.bind, args.postgres_port);
-    debug!("  Redis:      {}:{}", args.bind, args.redis_port);
-    debug!("  MySQL:      {}:{}", args.bind, args.mysql_port);
-    debug!("  CQL:        {}:{}", args.bind, args.cql_port);
-    debug!("  Cypher:     {}:7687", args.bind);
-    debug!("  AQL:        {}:8529", args.bind);
-    debug!("  Metrics:    {}:{}/metrics", args.bind, args.metrics_port);
+    info!("  gRPC:       {}:{}", args.bind, args.grpc_port);
+    info!("  REST API:   {}:{}", args.bind, args.http_port);
+    info!("  PostgreSQL: {}:{}", args.bind, args.postgres_port);
+    info!("  MySQL:      {}:{}", args.bind, args.mysql_port);
+    info!("  Redis:      {}:{}", args.bind, args.redis_port);
+    info!("  CQL:        {}:{}", args.bind, args.cql_port);
+    info!("  Cypher:     {}:7687", args.bind);
+    info!("  AQL:        {}:8529", args.bind);
+    info!("  MongoDB:    {}:27017", args.bind);
+    info!("  Metrics:    {}:{}/metrics", args.bind, args.metrics_port);
 
     // Initialize MCP server if enabled
     if toml_config

--- a/orbit/server/src/protocols/rest/server.rs
+++ b/orbit/server/src/protocols/rest/server.rs
@@ -93,23 +93,24 @@ impl RestApiServer {
         };
 
         // API v1 routes
+        // Note: Axum 0.7+ uses {param} syntax instead of :param
         let api_routes = Router::new()
             // Actor management
             .route("/actors", get(handlers::list_actors))
             .route("/actors", post(handlers::create_actor))
-            .route("/actors/:actor_type/:key", get(handlers::get_actor))
-            .route("/actors/:actor_type/:key", put(handlers::update_actor))
-            .route("/actors/:actor_type/:key", delete(handlers::delete_actor))
+            .route("/actors/{actor_type}/{key}", get(handlers::get_actor))
+            .route("/actors/{actor_type}/{key}", put(handlers::update_actor))
+            .route("/actors/{actor_type}/{key}", delete(handlers::delete_actor))
             .route(
-                "/actors/:actor_type/:key/invoke",
+                "/actors/{actor_type}/{key}/invoke",
                 post(handlers::invoke_actor),
             )
             // SQL Query endpoints
             .route("/sql", post(handlers::execute_sql_query))
             .route("/sql/batch", post(handlers::execute_batch_sql))
             .route("/tables", get(handlers::list_tables))
-            .route("/tables/:schema/:table", get(handlers::describe_table))
-            .route("/tables/:schema/:table/indexes", get(handlers::list_indexes))
+            .route("/tables/{schema}/{table}", get(handlers::describe_table))
+            .route("/tables/{schema}/{table}/indexes", get(handlers::list_indexes))
             .route("/schemas", get(handlers::list_schemas))
             .route("/queries/history", get(handlers::get_query_history))
             .route("/stats", get(handlers::get_database_stats))
@@ -120,11 +121,11 @@ impl RestApiServer {
             // Transactions
             .route("/transactions", post(handlers::begin_transaction))
             .route(
-                "/transactions/:transaction_id/commit",
+                "/transactions/{transaction_id}/commit",
                 post(handlers::commit_transaction),
             )
             .route(
-                "/transactions/:transaction_id/abort",
+                "/transactions/{transaction_id}/abort",
                 post(handlers::abort_transaction),
             )
             // Natural Language Queries (disabled - handlers not implemented)
@@ -138,7 +139,7 @@ impl RestApiServer {
             // )
             // WebSocket endpoints
             .route(
-                "/ws/actors/:actor_type/:key",
+                "/ws/actors/{actor_type}/{key}",
                 get(WebSocketHandler::handle_actor_socket),
             )
             .route("/ws/events", get(WebSocketHandler::handle_events_socket))

--- a/orbit/server/src/server.rs
+++ b/orbit/server/src/server.rs
@@ -197,6 +197,12 @@ impl OrbitServerBuilder {
         self
     }
 
+    /// Enable or disable MongoDB protocol server
+    pub fn with_mongodb_enabled(mut self, enabled: bool) -> Self {
+        self.config.protocols.mongodb_enabled = enabled;
+        self
+    }
+
     pub async fn build(self) -> OrbitResult<OrbitServer> {
         OrbitServer::new(self.config).await
     }
@@ -512,43 +518,10 @@ impl OrbitServer {
                 self.config.protocols.postgres_port
             );
         }
-        if self.config.protocols.mysql_enabled {
-            tracing::info!(
-                "  - MySQL: {}:{}",
-                self.config.protocols.mysql_bind_address,
-                self.config.protocols.mysql_port
-            );
-        }
-        if self.config.protocols.cql_enabled {
-            tracing::info!(
-                "  - CQL/Cassandra: {}:{}",
-                self.config.protocols.cql_bind_address,
-                self.config.protocols.cql_port
-            );
-        }
-        if self.config.protocols.cypher_enabled {
-            tracing::info!(
-                "  - Cypher/Neo4j: {}:{}",
-                self.config.protocols.cypher_bind_address,
-                self.config.protocols.cypher_port
-            );
-        }
-        if self.config.protocols.aql_enabled {
-            tracing::info!(
-                "  - AQL/ArangoDB: {}:{}",
-                self.config.protocols.aql_bind_address,
-                self.config.protocols.aql_port
-            );
-        }
-        if self.config.protocols.mongodb_enabled {
-            tracing::info!(
-                "  - MongoDB: {}:{}",
-                self.config.protocols.mongodb_bind_address,
-                self.config.protocols.mongodb_port
-            );
-        }
+        // Note: MySQL, CQL, Cypher, AQL, REST, and MongoDB protocols are started in main.rs
+        // with unified storage configuration. The status messages are printed there.
 
-        // Start MongoDB server if enabled
+        // Start MongoDB server if enabled (only used when running via OrbitServerBuilder directly)
         if self.config.protocols.mongodb_enabled {
             let mongo_addr = format!(
                 "{}:{}",


### PR DESCRIPTION
- Add REST API server startup in main.rs (port 8080)
- Add MongoDB server startup in main.rs (port 27017)
- Fix Axum route syntax from :param to {param} for Axum 0.7+
- Add with_mongodb_enabled() builder method to OrbitServerBuilder
- Bind MongoDB to 0.0.0.0 instead of 127.0.0.1 for localhost access
- Remove duplicate protocol status messages from server.rs
- All protocols now start consistently from main.rs with unified storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)